### PR TITLE
Bugfix/exception handling for api requests

### DIFF
--- a/app/constant/Messages.php
+++ b/app/constant/Messages.php
@@ -218,4 +218,9 @@ class Messages
     {
         return "$field alanı boş bırakılamaz.";
     }
+
+    public static function PAGE_NOT_FOUND()
+    {
+        return "Sayfa bulunamadı.";
+    }
 }

--- a/app/constant/Responses.php
+++ b/app/constant/Responses.php
@@ -31,6 +31,15 @@ abstract class Responses
         ];
     }
 
+    public static function PAGE_NOT_FOUND($message = Constants::DEFAULT_RESPONSE_MESSAGE)
+    {
+        return [
+            'title' => 'Sayfa Bulunamadı',
+            'message' => $message,
+            'code' => 404
+        ];
+    }
+
     public static function SUCCESS($message = Constants::DEFAULT_RESPONSE_MESSAGE)
     {
         return [

--- a/app/controller/PersonelController.php
+++ b/app/controller/PersonelController.php
@@ -13,11 +13,9 @@ use app\utility\CommonValidator;
 use app\utility\Popup;
 use app\utility\Token;
 use core\Controller;
-use core\Response;
 use core\Router;
 use core\View;
 use Exception;
-use http\Message;
 
 class PersonelController extends Controller
 {

--- a/app/controller/RestrictedController.php
+++ b/app/controller/RestrictedController.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace app\controller;
+
 use core\View;
 
 class RestrictedController extends LoginRequiredController

--- a/app/controller/api/HastaController.php
+++ b/app/controller/api/HastaController.php
@@ -2,9 +2,7 @@
 
 namespace app\controller\api;
 
-use app\constant\Constants;
 use app\constant\Constraints;
-use app\constant\Environment;
 use app\constant\Fields;
 use app\constant\Messages;
 use app\constant\Responses;

--- a/app/utility/CommonValidator.php
+++ b/app/utility/CommonValidator.php
@@ -4,7 +4,6 @@ namespace app\utility;
 
 use app\constant\Constraints;
 use app\constant\Messages;
-use app\constant\Environment;
 
 abstract class CommonValidator
 {

--- a/app/utility/Mail.php
+++ b/app/utility/Mail.php
@@ -3,11 +3,9 @@
 namespace app\utility;
 
 use app\constant\Constants;
-use app\constant\Fields;
 use app\constant\Messages;
 use app\constant\Responses;
 use config\Config;
-use core\Response;
 
 class Mail
 {

--- a/app/utility/UtilityFunctions.php
+++ b/app/utility/UtilityFunctions.php
@@ -2,6 +2,8 @@
 
 namespace app\utility;
 
+use core\Request;
+
 class UtilityFunctions
 {
     public static function turkish_lowercase($str)

--- a/app/view/calendar.php
+++ b/app/view/calendar.php
@@ -1,7 +1,6 @@
 <?php
 
 use app\constant\Constraints;
-use app\constant\Environment;
 use app\constant\Fields;
 use app\model\RandevuTuru;
 use app\utility\Auth;

--- a/app/view/home.php
+++ b/app/view/home.php
@@ -1,8 +1,6 @@
 <?php
 
-use app\model\Personel;
 use app\utility\Auth;
-use config\Config;
 
 $auth_personel = Auth::getAuthStaff();
 ?>

--- a/core/Error.php
+++ b/core/Error.php
@@ -2,6 +2,8 @@
 
 namespace core;
 
+use app\constant\Messages;
+use app\constant\Responses;
 use config\Config;
 use Exception;
 use ErrorException;
@@ -38,7 +40,14 @@ class Error
         if ($code != 404) {
             $code = 500;
         }
-        http_response_code($code);   
+        http_response_code($code);
+
+        if (Request::is_from_api()) {
+            self::writeLog(self::getMessage($exception));
+            Response::json([Responses::UNKNOWN_ERROR(Messages::UNKNOWN_ERROR())]);
+            exit;
+        }
+
         try {
             if (Config::SHOW_ERRORS) {
                 echo "<h1>Fatal Error</h1>";

--- a/core/Error.php
+++ b/core/Error.php
@@ -44,7 +44,12 @@ class Error
 
         if (Request::is_from_api()) {
             self::writeLog(self::getMessage($exception));
-            Response::json([Responses::UNKNOWN_ERROR(Messages::UNKNOWN_ERROR())]);
+
+            $payload = $code === 404
+                ? Responses::PAGE_NOT_FOUND(Messages::PAGE_NOT_FOUND())
+                : Responses::UNKNOWN_ERROR(Messages::UNKNOWN_ERROR());
+
+            Response::json([$payload], $code);
             exit;
         }
 
@@ -94,7 +99,10 @@ class Error
      */
     public static function writeLog($message)
     {
-        $log_file = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'logs' . DIRECTORY_SEPARATOR . date('Y-m-d') . '.txt';
+
+        $log_file = Request::is_from_api()
+            ? dirname(__DIR__) . DIRECTORY_SEPARATOR . 'logs' . DIRECTORY_SEPARATOR . 'api_log_' . date('Y-m-d') . '.txt'
+            : dirname(__DIR__) . DIRECTORY_SEPARATOR . 'logs' . DIRECTORY_SEPARATOR . 'portal_log_' . date('Y-m-d') . '.txt';
         ini_set('error_log', $log_file);
         error_log($message);
     }

--- a/core/Request.php
+++ b/core/Request.php
@@ -47,5 +47,24 @@ abstract class Request
         }
         return $method;
     }
-    
+
+    /**
+     * Returns true if the current request URI is from an API client
+     *
+     * @return bool
+     */
+    public static function is_from_api()
+    {
+        return preg_match('/^\/?api/', Request::uri());
+    }
+
+    /**
+     * Returns true if the current request URI is from a portal user
+     *
+     * @return bool
+     */
+    public static function is_from_portal()
+    {
+        return !preg_match('/^\/?api/', Request::uri());
+    }
 }


### PR DESCRIPTION
Changelog:

- Created two new functions in \core\Request class to determine whether the current request URI is from an API client or portal user.
- Added a new control flow into the exception handler function at \core\Error class to determine if the incoming request is made through an API client. If it's made from an API client, then it would write the stack trace on the default log path.
-  Log file paths are separated for portal and api side exceptions.
