### PR TITLE
Feature/generic-validator-has-been-implemented

### DIFF
--- a/app/constant/tr/Messages.php
+++ b/app/constant/tr/Messages.php
@@ -238,4 +238,19 @@ class Messages
     {
         return "$field alanı yalnızca tamsayı değerler içerebilir.";
     }
+
+    public static function SHOULD_BE_NUMERIC($field)
+    {
+        return "$field alanı yalnızca sayısal değerler içerebilir.";
+    }
+
+    public static function SHOULD_BE_IN_BETWEEN($min, $max, $field)
+    {
+        return "$field alanı $min ile $max arasında değerler içerebilir.";
+    }
+
+    public static function INVALID_IP_ADDR($field)
+    {
+        return "$field alanı için geçerli bir ip adresi girin.";
+    }
 }

--- a/app/utility/Validator.php
+++ b/app/utility/Validator.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace app\utility;
+
+use app\constant\Messages;
+
+class Validator
+{
+    private $errors = [];
+    private $value = '';
+    private $field_name = '';
+    private $stop_once = false;
+    private $errors_incremented = false;
+    private $stop = false;
+
+    public function __construct($value, $field_name)
+    {
+        $this->value = $value;
+        $this->field_name = $field_name;
+        return $this;
+    }
+
+    public function stop()
+    {
+        $this->stop = true;
+        return $this;
+    }
+
+    public function stop_once()
+    {
+        $this->stop_once = true;
+        return $this;
+    }
+
+    public function required()
+    {
+        if (!empty($this->errors) && $this->stop === true) {
+            return $this;
+        }
+
+        if ($this->errors_incremented === true && $this->stop_once === true) {
+            return $this;
+        }
+
+        if (empty($this->value)) {
+            $this->errors[] = Messages::CANNOT_BE_EMPTY($this->field_name);
+            $this->errors_incremented = $this->stop_once === true ? true : false;
+        }
+        return $this;
+    }
+
+    public function match($pattern, $error_message)
+    {
+        if (!empty($this->errors) && $this->stop === true) {
+            return $this;
+        }
+
+        if ($this->errors_incremented === true && $this->stop_once === true) {
+            return $this;
+        }
+
+        if (!preg_match($pattern, $this->value)) {
+            $this->errors[] = $error_message;
+            $this->errors_incremented = $this->stop_once === true ? true : false;
+        }
+        return $this;
+    }
+
+    public function min_len($length)
+    {
+        if (!empty($this->errors) && $this->stop === true) {
+            return $this;
+        }
+
+        if ($this->errors_incremented === true && $this->stop_once === true) {
+            return $this;
+        }
+
+        if (strlen($this->value) < $length) {
+            $this->errors[] = Messages::MIN_LEN($length, $this->field_name);
+            $this->errors_incremented = $this->stop_once === true ? true : false;
+        }
+        return $this;
+    }
+
+    public function max_len($length)
+    {
+        if (!empty($this->errors) && $this->stop === true) {
+            return $this;
+        }
+
+        if ($this->errors_incremented === true && $this->stop_once === true) {
+            return $this;
+        }
+
+        if (strlen($this->value) > $length) {
+            $this->errors[] = Messages::MAX_LEN($length, $this->field_name);
+            $this->errors_incremented = $this->stop_once === true ? true : false;
+        }
+        return $this;
+    }
+    
+    public function int()
+    {
+        if (!empty($this->errors) && $this->stop === true) {
+            return $this;
+        }
+
+        if ($this->errors_incremented === true && $this->stop_once === true) {
+            return $this;
+        }
+        
+        if (!preg_match('/^\d+$/', $this->value)) {
+            $this->errors[] = Messages::SHOULD_BE_INTEGER($this->field_name);
+            $this->errors_incremented = $this->stop_once === true ? true : false;
+        }
+        return $this;
+    }
+    
+    public function numeric()
+    {
+        if (!empty($this->errors) && $this->stop === true) {
+            return $this;
+        }
+
+        if ($this->errors_incremented === true && $this->stop_once === true) {
+            return $this;
+        }
+        
+        if (!preg_match('/(^\d+$)|(^\d+\.\d+$)/', $this->value)) {
+            $this->errors[] = Messages::SHOULD_BE_NUMERIC($this->field_name);
+            $this->errors_incremented = $this->stop_once === true ? true : false;
+        }
+        return $this;
+    }
+
+    public function between($min, $max)
+    {
+        if (!empty($this->errors) && $this->stop === true) {
+            return $this;
+        }
+
+        if ($this->errors_incremented === true && $this->stop_once === true) {
+            return $this;
+        }
+
+        if (!((float)$this->value >= $min && (float)$this->value <= $max)) {
+            $this->errors[] = Messages::SHOULD_BE_IN_BETWEEN($min, $max, $this->field_name);
+            $this->errors_incremented = $this->stop_once === true ? true : false;
+        }
+        return $this;
+    }
+
+    public function email()
+    {
+        if (!empty($this->errors) && $this->stop === true) {
+            return $this;
+        }
+
+        if ($this->errors_incremented === true && $this->stop_once === true) {
+            return $this;
+        } 
+        
+        if (!filter_var($this->value, FILTER_VALIDATE_EMAIL)) {
+            $this->errors[] = Messages::INVALID_EMAIL($this->field_name);
+            $this->errors_incremented = $this->stop_once === true ? true : false;
+        }
+    }
+    
+    public function ip_addr()
+    {
+        if (!empty($this->errors) && $this->stop === true) {
+            return $this;
+        }
+        
+        if ($this->errors_incremented === true && $this->stop_once === true) {
+            return $this;
+        }
+        
+        if (!preg_match('/^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$/', $this->value)) {
+            $this->errors[] = Messages::INVALID_IP_ADDR($this->field_name);
+            $this->errors_incremented = $this->stop_once === true ? true : false;            
+        }
+    }
+
+
+    public function isValid()
+    {
+        return empty($this->errors);
+    }
+
+    public function getErrors()
+    {
+        return $this->errors;
+    }
+
+}


### PR DESCRIPTION
stop_once() is used to terminate validation at first error after the current validation step.
stop() is used to terminate validation if there are validation errors so far. 

Syntax:

$validation = (new Validator(<value>, <field_name>))
    ->stop_once()
    ->min_len(5)
    ->max_len(20)
    ->stop()
    ->match(<regexp>, <msg>);

if (!$validation->isValid()) {
    foreach ($validation->getErrors() as $error_msg) {
        echo $error_msg . '<br>';
    }
}