### PR TITLE
_callStatic functions made static to avoid warning messages

### DIFF
--- a/app/constant/Constants.php
+++ b/app/constant/Constants.php
@@ -4,7 +4,7 @@ namespace app\constant;
 
 class Constants
 {
-    public function __callStatic($name, $arguments)
+    public static function __callStatic($name, $arguments)
     {
         $existing_class_name = ltrim(get_called_class(), '\\');
         $class_name_without_namespace = ltrim(get_called_class(), '\\');

--- a/app/constant/Fields.php
+++ b/app/constant/Fields.php
@@ -7,7 +7,7 @@ use core\Error;
 
 class Fields
 {
-    public function __callStatic($name, $arguments)
+    public static function __callStatic($name, $arguments)
     {
         $existing_class_name = ltrim(get_called_class(), '\\');
         $class_name_without_namespace = ltrim(get_called_class(), '\\');

--- a/app/constant/Messages.php
+++ b/app/constant/Messages.php
@@ -4,7 +4,7 @@ namespace app\constant;
 
 class Messages
 {
-    public function __callStatic($name, $arguments)
+    public static function __callStatic($name, $arguments)
     {
         $existing_class_name = ltrim(get_called_class(), '\\');
         $class_name_without_namespace = ltrim(get_called_class(), '\\');

--- a/app/constant/Responses.php
+++ b/app/constant/Responses.php
@@ -6,7 +6,7 @@ use core\Error;
 
 abstract class Responses
 {
-    public function __callStatic($name, $arguments)
+    public static function __callStatic($name, $arguments)
     {
         $existing_class_name = ltrim(get_called_class(), '\\');
         $class_name_without_namespace = ltrim(get_called_class(), '\\');


### PR DESCRIPTION
**Problem description:** PHP warnings were showing when system calls the _callStatic methods where at multilingual modules.

**Root Cause Analysis:** By definition, _callStatic() magic methods must be specified as public static. But in existing system they all were defined as just public methods.

**Solution:** All the _callStatic() function definitions preceded by a static keyword.