### PR TITLE
fixed error when user logs out after first registration

### DIFF
--- a/app/controller/UserController.php
+++ b/app/controller/UserController.php
@@ -93,6 +93,7 @@ class UserController extends Controller
                 throw new Exception(Messages::USER_COULD_NOT_BE_SAVED($user->getEmail()));
             }
             Popup::add(Responses::SUCCESS(Messages::REGISTER_SUCCESSFUL()));
+            unset($user);
             Router::redirectAfterPost('/');
         } else {
             View::render('signup.php', ['user' => $existing_user, 'errors' => $errors]);

--- a/app/utility/Auth.php
+++ b/app/utility/Auth.php
@@ -58,7 +58,9 @@ class Auth
     {
         if (isset($_COOKIE['last_session_id'])) {
             $existing_api_token_record = ApiToken::findBySessionId($_COOKIE['last_session_id']);
-            $existing_api_token_record->delete();
+            if ($existing_api_token_record !== false) {
+                $existing_api_token_record->delete();
+            }
         }
         $_SESSION = [];
         if (ini_get("session.use_cookies")) {


### PR DESCRIPTION
**Problem Description:** Error occurred when a newly registered user tries to logout.

**Root Cause Analysis:** Registered user is automatically set logged in by mistake because of the registered user model is assigned to $user identifier which is also used to welcome message to normally logged in users at home page view. As it is not intended, an error message was raising if this newly registered user tries to logout since there are no api token record is inserted into db and there are no control flow if an api token record is whether exists or not while trying to delete it on logout.

**Solution Description:** Made sure the $user variable has been unset before redirection to home page after a successful registration at usercontroller.php. Also added a control flow to check if there is an existing api token record before try to delete it at auth.php helper class.