### PR TITLE
CSRF Tokens have been implemented

### DIFF
--- a/app/constant/en/Messages.php
+++ b/app/constant/en/Messages.php
@@ -266,4 +266,9 @@ class Messages
     {
         return "$field field is invalid.";
     }
+
+    public static function INVALID_CSRF_TOKEN()
+    {
+        return "Invalid CSRF token.";
+    }
 }

--- a/app/constant/tr/Messages.php
+++ b/app/constant/tr/Messages.php
@@ -264,4 +264,9 @@ class Messages
     {
         return "$field alanı geçersiz.";
     }
+
+    public static function INVALID_CSRF_TOKEN()
+    {
+        return "CSRF anahtarı geçersiz.";
+    }
 }

--- a/app/controller/UserController.php
+++ b/app/controller/UserController.php
@@ -32,6 +32,13 @@ class UserController extends Controller
             throw new Exception($error['message'], $error['code']);
         }
 
+        if (Auth::isValidCsrfToken() === false) {
+            $message = \app\constant\en\Messages::INVALID_CSRF_TOKEN();
+            $error = \app\constant\en\Responses::UNAUTHORIZED_ACCESS($message);
+            Auth::setLastVisit('/user/signup');
+            throw new Exception($error['message'], $error['code']);
+        }
+
         $required_fields = ['first_name', 'last_name', 'email', 'password', 'group_id'];
         
         $missing_fields = array_diff($required_fields, array_keys($_POST));

--- a/app/model/CsrfToken.php
+++ b/app/model/CsrfToken.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace app\model;
+
+use core\Model;
+use PDO;
+
+class CsrfToken extends Model
+{
+    private $id = '';
+    private $last_session_id = '';
+    private $user_id = '';
+    private $csrf_token_hash = '';
+
+    public function __construct($args = [])
+    {
+        $class_vars = get_class_vars(get_called_class());
+
+        foreach ($args as $key => $value) {
+            if (isset($class_vars[$key])) {
+                $this->$key = $value;
+            }
+        }
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getLastSessionId()
+    {
+        return $this->last_session_id;
+    }
+
+    public function getCsrfTokenHash()
+    {
+        return $this->csrf_token_hash;
+    }
+
+    public function getUserId()
+    {
+        return $this->user_id;
+    }
+
+    public static function getByLastSessionId($last_session_id)
+    {
+        $sql = 'SELECT * FROM `csrf_tokens` WHERE `last_session_id` = :last_session_id';
+        $db = self::getDB();
+        $stmt = $db->prepare($sql);
+        $stmt->bindValue(':last_session_id', $last_session_id, PDO::PARAM_STR);
+        $stmt->setFetchMode(PDO::FETCH_CLASS, get_called_class());
+        $stmt->execute();
+        return $stmt->fetch();
+    }
+
+    public function save()
+    {
+        $sql = 'INSERT INTO `csrf_tokens` (`last_session_id`, `user_id`, `csrf_token_hash`)
+                VALUES (:last_session_id, :user_id, :csrf_token_hash)';
+        
+        $db = self::getDB();
+        $stmt = $db->prepare($sql);
+        $stmt->bindValue(':last_session_id', $this->last_session_id, PDO::PARAM_STR);
+        $stmt->bindValue(':user_id', $this->user_id, PDO::PARAM_INT);
+        $stmt->bindValue(':csrf_token_hash', $this->csrf_token_hash, PDO::PARAM_STR);
+        return $stmt->execute();
+    }
+
+    public function delete()
+    {
+        $sql = 'DELETE FROM `csrf_tokens` WHERE `id` = :id';
+        $db = self::getDB();
+        $stmt = $db->prepare($sql);
+        $stmt->bindValue(':id', $this->id, PDO::PARAM_INT);
+        return $stmt->execute();
+    }
+
+    public function update()
+    {
+        $sql = 'UPDATE `csrf_tokens`
+                SET `last_session_id` = :last_session_id,
+                    `user_id` = :user_id,
+                    `csrf_token_hash` = :csrf_token_hash
+                WHERE `id` = :id';
+        $db = self::getDB();
+        $stmt = $db->prepare($sql);
+        $stmt->bindValue(':id', $this->id, PDO::PARAM_INT);
+        $stmt->bindValue(':last_session_id', $this->last_session_id, PDO::PARAM_STR);
+        $stmt->bindValue(':user_id', $this->user_id, PDO::PARAM_INT);
+        $stmt->bindValue(':csrf_token_hash', $this->csrf_token_hash, PDO::PARAM_STR);
+        return $stmt->execute();
+    }
+}

--- a/app/utility/Auth.php
+++ b/app/utility/Auth.php
@@ -5,9 +5,11 @@ namespace app\utility;
 use app\constant\Messages;
 use app\constant\Responses;
 use app\model\ApiToken;
+use app\model\CsrfToken;
 use app\model\Language;
 use app\model\User;
 use config\Config;
+use core\Request;
 use core\Router;
 
 class Auth
@@ -31,13 +33,101 @@ class Auth
         $_SESSION['user_id'] = $user->getId();
 
         self::deleteApiToken();
+        self::deleteCsrfToken();
+
+        self::setLastSessionId();
 
         self::setApiToken($user->getId());
+        self::setCsrfToken($user->getId());
     }
 
-    public static function setLastVisit()
+    public static function setLastSessionId()
     {
-        $_SESSION['last_visit'] = $_SERVER['REQUEST_URI'];
+        $session_id = session_id();
+
+        if (isset($_COOKIE['last_session_id'])) {
+            unset($_COOKIE['last_session_id']);
+            setcookie("last_session_id", null, time() - 3600, "/");
+        }
+
+        setcookie('last_session_id', $session_id, time() + Datetime::WEEK, '/');
+    }
+
+    public static function deleteCsrfToken()
+    {
+        if (isset($_COOKIE['last_session_id'])) {
+            $existing_csrf_token_record = CsrfToken::getByLastSessionId($_COOKIE['last_session_id']);
+            if ($existing_csrf_token_record !== false) {
+                $existing_csrf_token_record->delete();
+            }
+
+            if (isset($_SESSION['csrf_token'])) {
+                unset($_SESSION['csrf_token']);
+            }
+        }        
+    }
+
+    public static function setCsrfToken($user_id)
+    {
+        self::deleteCsrfToken();
+
+        $token = new Token();
+
+        $last_session_id = session_id();
+
+        $csrf_token_record = new CsrfToken([
+            'last_session_id' => $last_session_id,
+            'user_id' => $user_id,
+            'csrf_token_hash' => $token->getHash()
+        ]);
+
+        $csrf_token_record->save();
+
+        $_SESSION['csrf_token'] = $token->getValue();
+    }
+
+    public static function setApiToken($user_id)
+    {
+        $api_token = new Token();
+
+        $last_session_id = session_id();
+
+        if (isset($_COOKIE['last_session_id'])) {
+            $last_session_id = $_COOKIE['last_session_id'];
+        }
+
+        $api_token_record = new ApiToken([
+            'last_session_id' => $last_session_id,
+            'user_id' => $user_id,
+            'api_token_hash' => $api_token->getHash()
+        ]);
+
+        $api_token_record->save();
+
+        setcookie('api_token', $api_token->getValue(), time() + Datetime::WEEK, '/');
+    }
+
+    public static function deleteApiToken()
+    {
+        if (isset($_COOKIE['last_session_id'])) {
+            $existing_api_token_record = ApiToken::findBySessionId($_COOKIE['last_session_id']);
+            if ($existing_api_token_record !== false) {
+                $existing_api_token_record->delete();
+            }
+
+            if (isset($_COOKIE['api_token'])) {
+                unset($_COOKIE['api_token']);
+                setcookie("api_token", null, time() - 3600, "/");
+            }
+        }
+    }
+
+    public static function setLastVisit($uri = false)
+    {
+        if ($uri === false) {
+            $uri = Request::uri();
+        }
+        $_SESSION['last_visit'] = $uri;
     }
 
     public static function getLastVisit()
@@ -56,12 +146,8 @@ class Auth
 
     public static function logout()
     {
-        if (isset($_COOKIE['last_session_id'])) {
-            $existing_api_token_record = ApiToken::findBySessionId($_COOKIE['last_session_id']);
-            if ($existing_api_token_record !== false) {
-                $existing_api_token_record->delete();
-            }
-        }
+        self::deleteApiToken();
+        self::deleteCsrfToken(); 
         $_SESSION = [];
         if (ini_get("session.use_cookies")) {
             $params = session_get_cookie_params();
@@ -71,35 +157,6 @@ class Auth
             );
         }
         session_destroy();
-    }
-
-    public static function setApiToken($user_id)
-    {
-        $new_session_id = session_id();
-
-        setcookie('last_session_id', $new_session_id, time() + Datetime::WEEK, '/');
-
-        $api_token = new Token();
-
-        $api_token_record = new ApiToken([
-            'last_session_id' => $new_session_id,
-            'user_id' => $user_id,
-            'api_token_hash' => $api_token->getHash()
-        ]);
-
-        $api_token_record->save();
-
-        setcookie('api_token', $api_token->getValue(), time() + Datetime::WEEK, '/');
-    }
-
-    public static function deleteApiToken()
-    {
-        if (isset($_COOKIE['last_session_id'])) {
-            $existing_api_token_record = ApiToken::findBySessionId($_COOKIE['last_session_id']);
-            if ($existing_api_token_record !== false) {
-                $existing_api_token_record->delete();
-            }
-        }
     }
 
     public static function getUserLanguage()
@@ -136,5 +193,21 @@ class Auth
         setcookie("language_preference", $language_row->getLanguage(), time() + Datetime::DAY * 30, "/");
 
         return $language_row->getLanguage();
+    }
+
+    public static function isValidCsrfToken()
+    {
+        if (!isset($_SESSION['csrf_token'])) {
+            return false;
+        }
+        $existing_csrf_token_record = CsrfToken::getByLastSessionId(session_id());
+        if ($existing_csrf_token_record === false) {
+            return false;
+        }
+        $token = new Token($_SESSION['csrf_token']);
+        if ($token->getHash() !== $existing_csrf_token_record->getCsrfTokenHash()) {
+            return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
Implemented the unique csrf tokens. Tokens are stored in $_SESSION super-global. Also hashed value of the token is inserted into database (table name: `csrf_tokens`). When a non-api request is sent to web-server, those tokens are going to be checked before continuing execution. This feature provides extra security apart from the authentication.

Test Results: 

Before the implementation: 
<img width="421" alt="image" src="https://user-images.githubusercontent.com/45673838/117478322-aafafd80-af67-11eb-8ba7-9b7aa361b4ba.png">

After the implementation:
<img width="426" alt="image" src="https://user-images.githubusercontent.com/45673838/117478412-c82fcc00-af67-11eb-85dd-722fd5bb430f.png">

Logs:
<img width="469" alt="image" src="https://user-images.githubusercontent.com/45673838/117478634-147b0c00-af68-11eb-9fa3-fbe893420925.png">


