### PR TITLE
Calendar set height callback fn has been implemented

### DIFF
--- a/public/assets/js/calendar_fullcalendar_definitions.js
+++ b/public/assets/js/calendar_fullcalendar_definitions.js
@@ -23,7 +23,6 @@ var calendar = new FullCalendar.Calendar(calendarEl, {
         prev: 'fa-angle-left',
         next: 'fa-angle-right'
     },
-    // height: "70vh",
     titleFormat: {
         year: 'numeric',
         month: 'long',

--- a/public/assets/js/calendar_fullcalendar_definitions.js
+++ b/public/assets/js/calendar_fullcalendar_definitions.js
@@ -23,7 +23,7 @@ var calendar = new FullCalendar.Calendar(calendarEl, {
         prev: 'fa-angle-left',
         next: 'fa-angle-right'
     },
-    height: "70vh",
+    // height: "70vh",
     titleFormat: {
         year: 'numeric',
         month: 'long',
@@ -45,7 +45,7 @@ var calendar = new FullCalendar.Calendar(calendarEl, {
         day: '2-digit',
         omitCommas: true
     },
-    slotDuration: '00:15:00',
+    slotDuration: '00:30:00',
     slotLabelInterval: '01:00',
     slotLabelFormat: {
         hour: '2-digit',
@@ -90,8 +90,6 @@ var calendar = new FullCalendar.Calendar(calendarEl, {
                     end: js_timestamp_to_unix_timestamp(calendar.view.activeEnd.getTime()),
                 })
             });
-    
-            console.log(list);
         
             list = await list.json();
             var status = list.status || false;
@@ -105,5 +103,16 @@ var calendar = new FullCalendar.Calendar(calendarEl, {
             }
         }
         fetch_appointments();
+    },
+    viewDidMount: function (view) {
+        var content_height = document.querySelector('#calendar table tr').offsetHeight;
+        if (calendar.view.type === 'timeGridWeek') {
+            content_height += document.querySelector('.fc-timegrid-slot-lane').offsetHeight * 20;
+            calendar.setOption('contentHeight', content_height);
+        } 
+        else {
+            content_height += document.querySelector('.fc-daygrid-day').offsetHeight * 7;
+            calendar.setOption('contentHeight', content_height);
+        }
     }
 });

--- a/public/assets/js/calendar_main.js
+++ b/public/assets/js/calendar_main.js
@@ -299,5 +299,4 @@ $('#submit').on('click', async function (e) {
         $('#modal').modal('hide');
     }
 });
-
 calendar.render();


### PR DESCRIPTION
Problem description: Content height must be equal to the sum of the row heights respectively starting from 08:00  to 17:00 on timegridweek view. Also content height must be equal to the height of the entire month view. On existing view-configuration, content height is not responsive to selected view.

Root Cause: Content height is set through a hard-coded value (70 percent of the viewport height). This should be set dynamically when the selected view rendered to DOM through an event handler callback function.

Solution Description: Content height is set to be adjusted dynamically when current view rendered to DOM through an event handler callback function.