### PR TITLE
Router has been updated to accept all valid regular expressions in the custom pattern of a variable route element.

### DIFF
--- a/core/Router.php
+++ b/core/Router.php
@@ -164,7 +164,7 @@ class Router
         $route = preg_replace('/:+/', ':', $route);
         $route = preg_replace('/\s/', '', $route);
         foreach ($route as $key => $value) {
-            if (preg_match('/^<([a-z-]+)(:[^>]*)>$/', $value, $matches)) {
+            if (preg_match('/^<([a-z-]+)(:.*)>$/', $value, $matches)) {
                 $route[$key] = $this->convertNamedGroupWithPattern($matches);
                 continue;
             } else if (preg_match('/^<([a-z-]+)>$/', $value, $matches)) {


### PR DESCRIPTION
**Problem Description:**
Dentapp's router was able to parse variable route elements with custom regex patterns. We have been using "<>" (angle brackets) to identify if the request path contains a variable route element. However when a route element contains ">" character in its custom pattern, it was rejected since it's reserved to identify ending of the entire route element.

**Root Cause:**
Router does not allow ">" character in the pattern of a variable route element implicitly.

**Solution Description:**
Router has been updated to accept all valid regular expressions in the pattern of a variable route element.
